### PR TITLE
fix: add quiz state reset on component unmount

### DIFF
--- a/src/core/feature/AsyncSorterWidget/AsyncSorterNavigation/AsyncSorterNavigation.tsx
+++ b/src/core/feature/AsyncSorterWidget/AsyncSorterNavigation/AsyncSorterNavigation.tsx
@@ -20,7 +20,6 @@ function AsyncSorterNavigation({
 
   const increaseQuestionNumber = useAsyncSorterStore((state) => state.increaseQuestionNumber);
   const decreaseQuestionNumber = useAsyncSorterStore((state) => state.decreaseQuestionNumber);
-  const resetQuizState = useAsyncSorterStore((state) => state.reset);
 
   return (
     <QuizNavigation
@@ -38,7 +37,6 @@ function AsyncSorterNavigation({
         }));
 
         await submitQuizAnswers(quizId, answersForApi);
-        resetQuizState();
       }}
     />
   );

--- a/src/core/feature/AsyncSorterWidget/AsyncSorterWidget.tsx
+++ b/src/core/feature/AsyncSorterWidget/AsyncSorterWidget.tsx
@@ -1,13 +1,20 @@
-import type { AsyncSorterTask } from './types';
+import { useEffect } from 'react';
 
+import { useAsyncSorterStore } from '@/core/store/asyncSorter.store';
+import type { AsyncSorterTask } from './types';
 import AsyncSorterQuizBody from './AsyncSorterQuizBody/AsyncSorterQuizBody';
 import AsyncSorterNavigation from './AsyncSorterNavigation/AsyncSorterNavigation';
 import AsyncSorterProgress from './AsyncSorterProgress/AsyncSorterProgress';
 
 function AsyncSorterWidget({ data }: { data: AsyncSorterTask }) {
   const { questions, id } = data;
-
   const questionsCount = questions.length;
+
+  const resetQuizState = useAsyncSorterStore((state) => state.reset);
+
+  useEffect(() => {
+    return () => resetQuizState();
+  }, [resetQuizState]);
 
   return (
     <div>

--- a/src/core/feature/CodeCompletionWidget/CodeCompletionNavigation/CodeCompletionNavigation.tsx
+++ b/src/core/feature/CodeCompletionWidget/CodeCompletionNavigation/CodeCompletionNavigation.tsx
@@ -18,7 +18,6 @@ function CodeCompletionNavigation({
 
   const increaseQuestionNumber = useCodeCompletionStore((state) => state.increaseQuestionNumber);
   const decreaseQuestionNumber = useCodeCompletionStore((state) => state.decreaseQuestionNumber);
-  const resetQuizState = useCodeCompletionStore((state) => state.reset);
 
   return (
     <QuizNavigation
@@ -34,7 +33,6 @@ function CodeCompletionNavigation({
         }));
 
         await submitQuizAnswers(quizId, answersForApi);
-        resetQuizState();
       }}
     />
   );

--- a/src/core/feature/CodeCompletionWidget/CodeCompletionWidget.tsx
+++ b/src/core/feature/CodeCompletionWidget/CodeCompletionWidget.tsx
@@ -1,13 +1,20 @@
-import type { CodeCompletionTask } from './types';
+import { useEffect } from 'react';
 
+import { useCodeCompletionStore } from '@/core/store/codeCompletion.store';
+import type { CodeCompletionTask } from './types';
 import CodeCompletionQuizBody from './CodeCompletionQuizBody/CodeCompletionQuizBody';
 import CodeCompletionNavigation from './CodeCompletionNavigation/CodeCompletionNavigation';
 import CodeCompletionProgress from './CodeCompletionProgress/CodeCompletionProgress';
 
 function CodeCompletionWidget({ data }: { data: CodeCompletionTask }) {
   const { questions, id } = data;
-
   const questionsCount = questions.length;
+
+  const resetQuizState = useCodeCompletionStore((state) => state.reset);
+
+  useEffect(() => {
+    return () => resetQuizState();
+  }, [resetQuizState]);
 
   return (
     <div>

--- a/src/core/feature/CodeOrderingWidget/CodeOrderingNavigation/CodeOrderingNavigation.tsx
+++ b/src/core/feature/CodeOrderingWidget/CodeOrderingNavigation/CodeOrderingNavigation.tsx
@@ -20,7 +20,6 @@ export default function CodeOrderingNavigation({
 
   const increaseQuestionNumber = useCodeOrderingStore((state) => state.increaseQuestionNumber);
   const decreaseQuestionNumber = useCodeOrderingStore((state) => state.decreaseQuestionNumber);
-  const resetQuizState = useCodeOrderingStore((state) => state.reset);
 
   return (
     <QuizNavigation
@@ -38,7 +37,6 @@ export default function CodeOrderingNavigation({
         }));
 
         await submitQuizAnswers(quizId, answersForApi);
-        resetQuizState();
       }}
     />
   );

--- a/src/core/feature/CodeOrderingWidget/CodeOrderingWidget.tsx
+++ b/src/core/feature/CodeOrderingWidget/CodeOrderingWidget.tsx
@@ -1,13 +1,20 @@
-import type { CodeOrderingTask } from './types';
+import { useEffect } from 'react';
 
+import { useCodeOrderingStore } from '@/core/store/codeOrdering.store';
+import type { CodeOrderingTask } from './types';
 import CodeOrderingQuizBody from './CodeOrderingQuizBody/CodeOrderingQuizBody';
 import CodeOrderingNavigation from './CodeOrderingNavigation/CodeOrderingNavigation';
 import CodeOrderingProgress from './CodeOrderingProgress/CodeOrderingProgress';
 
 export default function CodeOrderingWidget({ data }: { data: CodeOrderingTask }) {
   const { questions, id } = data;
-
   const questionsCount = questions.length;
+
+  const resetQuizState = useCodeOrderingStore((state) => state.reset);
+
+  useEffect(() => {
+    return () => resetQuizState();
+  }, [resetQuizState]);
 
   return (
     <div>


### PR DESCRIPTION
#67 
Исправлено сохранение состояния квизов, использующих Zustand. Теперь состояние сбрасывается при размонтировании компонента, а не после отправки ответов. 